### PR TITLE
Use db is valid in last connection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: berdie
 Type: Package
 Title: Berdie
-Version: 0.1.1
+Version: 0.1.2
 Description: Berdie is an R package for synchronizing data sources across two
     separate layers.
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/R/last_connection.R
+++ b/R/last_connection.R
@@ -10,11 +10,20 @@
 #' @seealso \code{\link{postgresql_connection}}
 #' @export
 last_connection <- function() {
-  get_cache('last_connection') %||%
+  conn <- get_cache('last_connection')
+  if (is(conn, "error")) {
+    conn <- NULL
+  }
+  if (is(conn, 'PqConnection')) {
+    isValidConnection <- tryCatch(dbIsValid(dbSendQuery(conn, 'select 1')), error = function(e) FALSE)
+    if (!isValidConnection)
+      conn <- NULL
+  }
+
+  conn %||%
   postgresql_connection(getOption('berdie.database.yml'), strict = FALSE) %||%
   (if ('syberia' %in% .packages())
      postgresql_connection(strict = FALSE,
        file.path(syberiaStructure::syberia_root(), 'config', 'database.yml'))
    else NULL)
 }
-


### PR DESCRIPTION
Hey @robertzk 
this is meant to address the issue of establishing a connection at time t0 and then trying to do a ```run_query``` at time t >> t0. The connection breaks after a prolonged period (such as when we recache batch data in between establishing the connection and executing a ```run_query```)

As it stands in master, ```last_connection()``` simply returns the cached connection object and does not check if the connection is still valid. I am using ```RPostres::dbIsValid()``` to check if the connection is still intact before we run ```DBI::dbGetQuery(conn, query)``` on a broken connection object. If ```RPostres::dbIsValid``` returns ```FALSE```, it will make an attempt to reconnect.

Note: ```RPostres::dbIsValid``` has not been implemented for ```PqConnection``` objects, but has been implemented for ```PqResult``` objects.

